### PR TITLE
Fix reading magic value for SHTXF

### DIFF
--- a/dr12ae/shtx_conv.py
+++ b/dr12ae/shtx_conv.py
@@ -52,8 +52,8 @@ def convert_shtx(data):
   if not data[:4] == SHTX_MAGIC:
     return
   
-  if data[:6] == SHTXF_MAGIC:
-    img = convert_shtx_8bit(data[6:])
+  if data[:5] == SHTXF_MAGIC:
+    img = convert_shtx_8bit(data[5:])
   
   else:
     img = convert_shtx_4bit(data[4:])


### PR DESCRIPTION
Since the magic value was shortened to 5 bytes, comparing the value against 6 bytes of data would always return false. As a result, the script would incorrectly attempt to read 8-bit textures as 4-bit, causing a crash.